### PR TITLE
fix: Ensure modal close button remains clickable

### DIFF
--- a/_src/_assets/css/layout.scss
+++ b/_src/_assets/css/layout.scss
@@ -188,6 +188,7 @@ figure {
   top: 0;
   right: 1em;
   cursor: pointer;
+  z-index: 1;
   &:after {
     content: "×";
     color: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
Hey Chris 👋 

I really enjoyed the ShopTalk Show episode about this project! Was just playing around with it on my phone and noticed that I couldn't press the close button of the navigation overlay, then did a little investigation and found that it gets covered by the margin of the first nav item.

Feel free to accept/reject this PR as you like, and thanks for all you do!